### PR TITLE
fix r2mod li to use automatic colors

### DIFF
--- a/r2mod
+++ b/r2mod
@@ -746,7 +746,7 @@ case $1 in
     hol*) toggle_hold "$2";;
     imp*) profile_import "$2" "$3";;
     ins*) get_pkgs && install_mult_mods "${@:2}";;
-    li*)  ls -1 --color=always --group-directories-first "$PLUGINS_DIR";;
+    li*)  ls -1 --color=auto --group-directories-first "$PLUGINS_DIR";;
     ref*) get_pkgs 1;;
     run) launch_game;;
     sea*) get_pkgs && search_pkgs "$2";;


### PR DESCRIPTION
ls is capable of automatically determining an interactive shell from a script, and setting it to auto avoids the need for removing ANSI escape codes when piping std-out into a file or editor. interactive output remains coloured.