### PR TITLE
Check for XDG XDG_DATA_HOME when resolving Risk of Rain directory

### DIFF
--- a/r2mod
+++ b/r2mod
@@ -9,8 +9,7 @@ VERSION="1.2.0"
 STEAM_ID="632360"
 
 # Dirs
-STEAM_DIR=".local/share/Steam"
-FLATPAK_DIR=".var/app/com.valvesoftware.Steam/$STEAM_DIR"
+FLATPAK_DIR=".var/app/com.valvesoftware.Steam/.local/share/Steam"
 
 if [[ -n "$R2MOD_INSTALL_DIR" ]]; then
 	# Custom install location
@@ -20,7 +19,7 @@ elif [[ -d "$HOME/$FLATPAK_DIR/steamapps/common/Risk of Rain 2" ]]; then
 	R2_DIR="$HOME/$FLATPAK_DIR/steamapps/common/Risk of Rain 2"
 else
 	# Default
-	R2_DIR="$HOME/$STEAM_DIR/steamapps/common/Risk of Rain 2"
+	R2_DIR="${XDG_DATA_HOME:-"$HOME/.local/share"}/Steam/steamapps/common/Risk of Rain 2"
 fi
 
 if [[ -n "$R2MOD_COMPAT_DIR" ]]; then
@@ -31,7 +30,7 @@ elif [[ -d "$HOME/$FLATPAK_DIR/steamapps/compatdata/$STEAM_ID" ]]; then
 	R2_COMPAT="$HOME/$FLATPAK_DIR/steamapps/compatdata/$STEAM_ID"
 else
 	# Default
-	R2_COMPAT="$HOME/$STEAM_DIR/steamapps/compatdata/$STEAM_ID"
+	R2_COMPAT="${XDG_DATA_HOME:-"$HOME/.local/share"}/Steam/steamapps/compatdata/$STEAM_ID"
 fi
 
 BEPIN_DIR="$R2_DIR/BepInEx"


### PR DESCRIPTION
When not specifying a custom install location (`R2MOD_INSTALL_DIR`) or a Flatpack installation directory, it uses XDG_DATA_HOME if it exists (and is not null or empty), since that's how Steam resolves it's data directory. Of course, there is a fallback to the default location

without this change, the script won't work if XDG_DATA_HOME is set to some other directory besides `$HOME/.local/share`

I didn't change the Flatpack one because I have not tested it

All tests pass on my machine
```sh
➤ ./test.sh 
→ Testing Setting up BepInEx
→ Testing Installing Mods
  → Bad Mod Names
  → Valid Names, Invalid Mods
  → Valid Mod, Check Install
  → Valid Mod, Check Patcher
  → Valid Mod, Check Dependencies
→ Testing Hold
  → Bad Mod Names
  → Valid Mod, Check Hold
→ Testing Toggling
  → Bad Mod Names
  → Valid Mod, Invalid Dir
  → Valid Mod, Check Disable
  → Check Disable All
  → Check Enable All
→ Testing Uninstalling Mods
  → Invalid Mod Name
  → Valid Mod Name, but Not Installed
  → Valid Mod Name, but Core Mod
  → Valid Mod
  → Valid Mod, Check Patcher
→ Testing Importing Profiles
  → Invalid Profile Name
→ Removing Test Dir
→ Test Done!
```