### PR TITLE
add option to list only the names of mods, without the version

### DIFF
--- a/completions/bash/r2mod.sh
+++ b/completions/bash/r2mod.sh
@@ -57,7 +57,7 @@ _r2mod()
 					return 0
 					;;
 				li | list | ls)
-					local args="all count"
+					local args="all count names"
 					COMPREPLY=( $(compgen -W "$args" -- "$cur" ) )
 					return 0
 					;;

--- a/completions/zsh/_r2mod
+++ b/completions/zsh/_r2mod
@@ -94,9 +94,9 @@ _r2mod ()
 
 					case $line[2] in
 						"")
-							args=( "all" "count" )
+							args=( "all" "count" "names" )
 							;;
-						c | count)
+						c | count | n | names)
 							args=( "all" )
 							;;
 						*)

--- a/r2mod
+++ b/r2mod
@@ -530,8 +530,11 @@ function is_core_mod { [[ "$1" =~ ^($BEPIN_STRING|$R2API_STRING|$HOOKGEN_STRING)
 function list_installed {
 	local list_all
 	local mod
+	local names_only
 	local last_arg=${@: -1}
+	
 	[[ "$last_arg" =~ ^a(ll)?$ ]] && list_all=1
+	[[ "$1" =~ ^n(ames)?$ ]] && names_only=1
 
 	# Count Plugins
 	if [[ "$1" =~ ^c(ount)?$ ]]; then
@@ -542,25 +545,12 @@ function list_installed {
 		else
 			find_mods "$PLUGINS_DIR" | wc -l
 		fi
-	elif [[ "$1" =~ ^n(ames)?$ ]]; then
-		[[ -n "$list_all" ]] && cecho p "Enabled Plugins:"
-
-		find_mods "$PLUGINS_DIR" | while read -r mod; do
-			colorize_mod_name "${mod%-*}"
-		done
-
-		if [[ -n "$list_all" ]]; then
-			echo
-			cecho p "Disabled Plugins:"
-			find_mods "$PLUGINS_DISABLED_DIR" | while read -r mod; do
-				colorize_mod_name "$mod"
-			done
-		fi
 	else
 	# List Plugin Names
 		[[ -n "$list_all" ]] && cecho p "Enabled Plugins:"
 
 		find_mods "$PLUGINS_DIR" | while read -r mod; do
+			[[ -n "$names_only" ]] && mod="${mod%-[0-9]*.[0-9]*.[0-9]*}"
 			colorize_mod_name "$mod"
 		done
 
@@ -568,6 +558,7 @@ function list_installed {
 			echo
 			cecho p "Disabled Plugins:"
 			find_mods "$PLUGINS_DISABLED_DIR" | while read -r mod; do
+				[[ -n "$names_only" ]] && mod="${mod%-[0-9]*.[0-9]*.[0-9]*}"
 				colorize_mod_name "$mod"
 			done
 		fi

--- a/r2mod
+++ b/r2mod
@@ -114,7 +114,7 @@ function help {
 	r2mod hol(d): Toggle Mod Updates
 	r2mod imp(ort) ProfileCode: Install r2modman mod profile
 	r2mod ins(tall) Mod-Dependency-String: Install New Mod
-	r2mod li(st) (count|all) : List or Count Installed Mods
+	r2mod li(st) (count|names|all) : List, list only mod names, or Count Installed Mods
 	r2mod loa(d) ProfileName: Import Local Profile
 	r2mod ref(resh): Force Refresh Package Cache
 	r2mod run: Launch Risk of Rain
@@ -541,6 +541,20 @@ function list_installed {
 			cecho p "Disabled Plugins: $(find_mods "$PLUGINS_DISABLED_DIR" | wc -l)"
 		else
 			find_mods "$PLUGINS_DIR" | wc -l
+		fi
+	elif [[ "$1" =~ ^n(ames)?$ ]]; then
+		[[ -n "$list_all" ]] && cecho p "Enabled Plugins:"
+
+		find_mods "$PLUGINS_DIR" | while read -r mod; do
+			colorize_mod_name "${mod%-*}"
+		done
+
+		if [[ -n "$list_all" ]]; then
+			echo
+			cecho p "Disabled Plugins:"
+			find_mods "$PLUGINS_DISABLED_DIR" | while read -r mod; do
+				colorize_mod_name "$mod"
+			done
 		fi
 	else
 	# List Plugin Names


### PR DESCRIPTION
adds a "names" argument to `r2mod list`
  
`r2mod list`
```Moffein-MobileTurretBuff-1.1.8
Skell-GoldenCoastPlus-0.6.3
egpimp-EggsUtils-1.1.2
HIFU-HIFUEngineerTweaks-1.0.5
ThinkInvis-Hypercrit-2.0.3
amogus_lovers-StandaloneAncientScepter-1.1.1
...
```
  
`r2mod list names`
```Moffein-MobileTurretBuff
Skell-GoldenCoastPlus
egpimp-EggsUtils
HIFU-HIFUEngineerTweaks
ThinkInvis-Hypercrit
amogus_lovers-StandaloneAncientScepter
...
```
