### PR TITLE
add fish completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ bin:
 completions:
 	install -D -m 644 "completions/bash/r2mod.sh" "${DESTDIR}${PREFIX}/share/bash-completion/completions/r2mod"
 	install -D -m 644 "completions/zsh/_r2mod" "${DESTDIR}${PREFIX}/share/zsh/site-functions/_r2mod"
+	install -D -m 644 "completions/fish/r2mod.fish" "${DESTDIR}${PREFIX}/share/fish/completions/r2mod.fish"
 
 flatpak:
 	install -D -m 755 r2mod "${FLATPAK_DEST}/bin/r2mod"
@@ -17,3 +18,4 @@ flatpak:
 	install -D -m 644 flatpak/${FLATPAK_ID}.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
 	install -D -m 644 completions/zsh/_r2mod ${FLATPAK_DEST}/data/completions/zsh/_r2mod
 	install -D -m 644 completions/bash/r2mod.sh ${FLATPAK_DEST}/data/completions/bash/r2mod.sh
+	install -D -m 644 completions/fish/r2mod.fish ${FLATPAK_DEST}/data/completions/fish/r2mod.fish

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ All Files, Old Versions, and Backups can be found in `/tmp/r2mod`
 
 ## Changelog
 
+### 1.3.4
+
+- Added completion for fish
+
 ### 1.3.3
 
 - Updated ModCode Import/Export to new Thunderstore API

--- a/completions/fish/r2mod.fish
+++ b/completions/fish/r2mod.fish
@@ -1,0 +1,76 @@
+set -l subcommands check delete disable edit enable export hold import install load list refresh remove run save search setup uninstall update version
+set -l subcommands_short ch del dis ed en exp hol imp ins li ls loa ref rem sav sea set un upd ver
+
+function __fish_r2mod_nth
+	test (count (commandline -poc)) = $argv[1]
+end
+
+function __fish_bepin_dir
+	if set -q R2MOD_INSTALL_DIR
+		echo $R2MOD_INSTALL_DIR/BepInEx
+	else if test -d "$HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Risk of Rain 2"
+		echo "$HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Risk of Rain 2/BepInEx"
+	else
+		echo "$HOME/.local/share/Steam/steamapps/common/Risk of Rain 2/BepInEx"
+	end
+end
+
+function __fish_r2mod_configs
+	path basename (__fish_bepin_dir)/config/**
+end
+function __fish_r2mod_disabled
+	path basename (__fish_bepin_dir)/plugins_disabled/* \
+		| string match --invert -r "^(.*R2API.*|MMHOOK|RoR2BepInExPack|bbepis-BepInExPack-.*|RiskofThunder-HookGenPatcher-.*)"
+end
+function __fish_r2mod_enabled
+	path basename (__fish_bepin_dir)/plugins/* \
+		| string match --invert -r "^(.*R2API.*|MMHOOK|RoR2BepInExPack|bbepis-BepInExPack-.*|RiskofThunder-HookGenPatcher-.*)"
+end
+function __fish_r2mod_remote_plugins
+	set -l cc /tmp/r2mod/comp_cache
+	test -f $cc && cat $cc
+end
+function __fish_r2mod_profiles
+	path basename (
+		if set -q XDG_CONFIG_HOME
+			echo "$XDG_CONFIG_HOME"
+		else
+			echo "$HOME/.config"
+		end)/r2mod_cli/profiles/* | string replace -f ".zip" ""
+end
+function __fish_r2mod_imports
+	path basename /tmp/r2mod/profile/* | string match --invert -r '(\.|_|^config$|^new$)'
+end
+
+complete -c r2mod -c io.github.Foldex.r2mod -f
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a check -d "Check for Script Updates"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a delete -d "Delete a Profile"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a disable -d "Disable Mods"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a edit -d "Edit Mod Configs"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a enable -d "Enable Mods"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a export -d "Export r2modman mod profile"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a hold -d "Toggle Mod Updates"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a import -d "Import r2modman mod profile"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a install -d "Install New Mod"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a load -d "Load a Profile"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a list -d "List Installed Mods"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a refresh -d "Force Refresh Package Cache"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a remove -d "Uninstall a mod"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a run -d "Launch Risk of Rain"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a save -d "Save a Profile"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a search -d "Search for Mods"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a setup -d "Install a Fresh BepInEx Setup"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a uninstall -d "Uninstall a mod"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a update -d "Update All Existing Mods"
+complete -c r2mod -c io.github.Foldex.r2mod -n "not __fish_seen_subcommand_from $subcommands $subcommands_short" -a version -d "Print Version"
+
+complete -c r2mod -c io.github.Foldex.r2mod -n "__fish_seen_subcommand_from ed edit && __fish_r2mod_nth 2" -a "(__fish_r2mod_configs)"
+complete -c r2mod -c io.github.Foldex.r2mod -n "__fish_seen_subcommand_from en enable && __fish_r2mod_nth 2" -a "(__fish_r2mod_disabled)"
+complete -c r2mod -c io.github.Foldex.r2mod -n "__fish_seen_subcommand_from dis disable un uninstall hol hold rem remove && __fish_r2mod_nth 2" -a "(__fish_r2mod_enabled)"
+complete -c r2mod -c io.github.Foldex.r2mod -n "__fish_seen_subcommand_from ins install && __fish_r2mod_nth 2" -a "(__fish_r2mod_remote_plugins)"
+complete -c r2mod -c io.github.Foldex.r2mod -n "__fish_seen_subcommand_from loa load del delete sav save && __fish_r2mod_nth 2" -a "(__fish_r2mod_profiles)"
+complete -c r2mod -c io.github.Foldex.r2mod -n "__fish_seen_subcommand_from imp import && __fish_r2mod_nth 2" -a "(__fish_r2mod_imports)"
+complete -c r2mod -c io.github.Foldex.r2mod -n "__fish_seen_subcommand_from imp import && __fish_r2mod_nth 3" -a preview
+
+complete -c r2mod -c io.github.Foldex.r2mod -n "__fish_seen_subcommand_from li list ls && not __fish_seen_subcommand_from count names" -a "count names"
+complete -c r2mod -c io.github.Foldex.r2mod -n "__fish_seen_subcommand_from li list ls && not __fish_seen_subcommand_from all" -a "all"

--- a/r2mod
+++ b/r2mod
@@ -282,7 +282,7 @@ function flatpak_comp_install {
 	local share="$R2_XDG_DATA_DIR"
     local bash_install="$share/bash-completion/completions/$FLATPAK_ID"
     local zsh_install="$share/zsh/site-functions/_$FLATPAK_ID"
-    local fish_install="$share/fish/vendor_completions.d/$FLATPAK_ID.sh"
+    local fish_install="$share/fish/vendor_completions.d/$FLATPAK_ID.fish"
 
     local comp_ver="$XDG_DATA_HOME/.last_installed_completion"
     local last_comp_ver=0
@@ -320,7 +320,7 @@ function flatpak_comp_install {
 
     cecho b "Fish..." 1
     mkdir -p "$share/fish/vendor_completions.d/"
-    cp -f "/app/data/completions/fish/r2mod.sh" "$fish_install"
+    cp -f "/app/data/completions/fish/r2mod.fish" "$fish_install"
 
     echo "$COMPLETION_VER" > "$comp_ver"
 }

--- a/r2mod
+++ b/r2mod
@@ -10,7 +10,7 @@ STEAM_ID="632360"
 
 # r2mod Flatpak
 FLATPAK_ID="io.github.Foldex.r2mod"
-COMPLETION_VER="1"
+COMPLETION_VER="2"
 
 # Dirs
 FLATPAK_DIR=".var/app/com.valvesoftware.Steam/.local/share/Steam"
@@ -282,6 +282,7 @@ function flatpak_comp_install {
 	local share="$R2_XDG_DATA_DIR"
     local bash_install="$share/bash-completion/completions/$FLATPAK_ID"
     local zsh_install="$share/zsh/site-functions/_$FLATPAK_ID"
+    local fish_install="$share/fish/vendor_completions.d/$FLATPAK_ID.sh"
 
     local comp_ver="$XDG_DATA_HOME/.last_installed_completion"
     local last_comp_ver=0
@@ -290,11 +291,11 @@ function flatpak_comp_install {
     # So we know when to overwrite the existing ones
     [[ -f "$comp_ver" ]] && last_comp_ver=$(cat "$comp_ver")
     [[ ! $last_comp_ver =~ ^[0-9]+$ ]] && last_comp_ver=0
-    [[ "$COMPLETION_VER" -le "$last_comp_ver" && -f "$zsh_install" && -f "$bash_install" ]] && return
+    [[ "$COMPLETION_VER" -le "$last_comp_ver" && -f "$zsh_install" && -f "$bash_install" && -f "$fish_install" ]] && return
 
     cecho b "Installing Shell Completions"
 
-    if [[ ! -f "$bash_install" && ! -f "$zsh_install" ]]; then
+    if [[ ! -f "$bash_install" && ! -f "$zsh_install" && ! -f "$fish_install" ]]; then
         cecho p "You may wish to alias io.github.Foldex.r2mod to r2mod"
         cecho p "alias r2mod='flatpak run io.github.Foldex.r2mod'"
     fi
@@ -316,6 +317,10 @@ function flatpak_comp_install {
 
     mkdir -p "$share/zsh/site-functions/"
     cp -f "/app/data/completions/zsh/_r2mod" "$zsh_install"
+
+    cecho b "Fish..." 1
+    mkdir -p "$share/fish/vendor_completions.d/"
+    cp -f "/app/data/completions/fish/r2mod.sh" "$fish_install"
 
     echo "$COMPLETION_VER" > "$comp_ver"
 }


### PR DESCRIPTION
I added a completion script for fish. I don't know flatpak, so I wasn't sure how to get the completion to where it needs to be (`$HOME/.local/share/fish/vendor_completions.d/<command name>.fish`) if the user installs it via flatpak, and didn't add code for that; I'd appreciate any help with that :)